### PR TITLE
Update tournament round names to German terminology

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ DEFAULT_DATA = {
     'bracket': {
         'tournament_id': None,
         'status': 'not_setup',
-        'current_round': 'round1',
+        'current_round': 'Achtelfinale',
         'current_match_id': None,
         'matches': {},
         'bracket_positions': {}
@@ -74,7 +74,7 @@ def create_empty_bracket():
     bracket = {
         'tournament_id': str(uuid.uuid4()),
         'status': 'setup',
-        'current_round': 'round1',
+        'current_round': 'Achtelfinale',
         'current_match_id': None,
         'matches': {},
         'bracket_positions': {}
@@ -87,21 +87,21 @@ def create_empty_bracket():
             'robot2': 'TBD',
             'winner': None,
             'completed': False,
-            'round': 'round1'
+            'round': 'Achtelfinale'
         }
     
     # Quarterfinals: 4 matches (8 → 4)
-    bracket['matches']['qf_m1'] = {'robot1': 'winner_r1_m1', 'robot2': 'winner_r1_m2', 'winner': None, 'completed': False, 'round': 'quarterfinals'}
-    bracket['matches']['qf_m2'] = {'robot1': 'winner_r1_m3', 'robot2': 'winner_r1_m4', 'winner': None, 'completed': False, 'round': 'quarterfinals'}
-    bracket['matches']['qf_m3'] = {'robot1': 'winner_r1_m5', 'robot2': 'winner_r1_m6', 'winner': None, 'completed': False, 'round': 'quarterfinals'}
-    bracket['matches']['qf_m4'] = {'robot1': 'winner_r1_m7', 'robot2': 'winner_r1_m8', 'winner': None, 'completed': False, 'round': 'quarterfinals'}
+    bracket['matches']['qf_m1'] = {'robot1': 'winner_r1_m1', 'robot2': 'winner_r1_m2', 'winner': None, 'completed': False, 'round': 'Viertelfinale'}
+    bracket['matches']['qf_m2'] = {'robot1': 'winner_r1_m3', 'robot2': 'winner_r1_m4', 'winner': None, 'completed': False, 'round': 'Viertelfinale'}
+    bracket['matches']['qf_m3'] = {'robot1': 'winner_r1_m5', 'robot2': 'winner_r1_m6', 'winner': None, 'completed': False, 'round': 'Viertelfinale'}
+    bracket['matches']['qf_m4'] = {'robot1': 'winner_r1_m7', 'robot2': 'winner_r1_m8', 'winner': None, 'completed': False, 'round': 'Viertelfinale'}
     
     # Semifinals: 2 matches (4 → 2)
-    bracket['matches']['sf_m1'] = {'robot1': 'winner_qf_m1', 'robot2': 'winner_qf_m2', 'winner': None, 'completed': False, 'round': 'semifinals'}
-    bracket['matches']['sf_m2'] = {'robot1': 'winner_qf_m3', 'robot2': 'winner_qf_m4', 'winner': None, 'completed': False, 'round': 'semifinals'}
+    bracket['matches']['sf_m1'] = {'robot1': 'winner_qf_m1', 'robot2': 'winner_qf_m2', 'winner': None, 'completed': False, 'round': 'Halbfinale'}
+    bracket['matches']['sf_m2'] = {'robot1': 'winner_qf_m3', 'robot2': 'winner_qf_m4', 'winner': None, 'completed': False, 'round': 'Halbfinale'}
     
     # Finals: 1 match (2 → 1)
-    bracket['matches']['final'] = {'robot1': 'winner_sf_m1', 'robot2': 'winner_sf_m2', 'winner': None, 'completed': False, 'round': 'finals'}
+    bracket['matches']['final'] = {'robot1': 'winner_sf_m1', 'robot2': 'winner_sf_m2', 'winner': None, 'completed': False, 'round': 'Finale'}
     
     # Initialize bracket positions (1-16)
     for i in range(1, 17):
@@ -521,7 +521,7 @@ def _update_first_round_matches(bracket):
                 'robot2': 'TBD',
                 'winner': None,
                 'completed': False,
-                'round': 'round1'
+                'round': 'Achtelfinale'
             }
     
     # Update matches based on bracket positions
@@ -595,7 +595,7 @@ def reset_bracket():
     data['bracket'] = {
         'tournament_id': None,
         'status': 'not_setup',
-        'current_round': 'round1',
+        'current_round': 'Achtelfinale',
         'current_match_id': None,
         'matches': {},
         'bracket_positions': {}

--- a/templates/control.html
+++ b/templates/control.html
@@ -1044,20 +1044,20 @@
                 return;
             }
             
-            // Round 1
-            const round1 = createRoundDiv('Round 1', ['r1_m1', 'r1_m2', 'r1_m3', 'r1_m4', 'r1_m5', 'r1_m6', 'r1_m7', 'r1_m8']);
+            // Achtelfinale
+            const round1 = createRoundDiv('Achtelfinale', ['r1_m1', 'r1_m2', 'r1_m3', 'r1_m4', 'r1_m5', 'r1_m6', 'r1_m7', 'r1_m8']);
             container.appendChild(round1);
             
-            // Quarterfinals
-            const qf = createRoundDiv('Quarterfinals', ['qf_m1', 'qf_m2', 'qf_m3', 'qf_m4']);
+            // Viertelfinale
+            const qf = createRoundDiv('Viertelfinale', ['qf_m1', 'qf_m2', 'qf_m3', 'qf_m4']);
             container.appendChild(qf);
             
-            // Semifinals
-            const sf = createRoundDiv('Semifinals', ['sf_m1', 'sf_m2']);
+            // Halbfinale
+            const sf = createRoundDiv('Halbfinale', ['sf_m1', 'sf_m2']);
             container.appendChild(sf);
             
-            // Finals
-            const finals = createRoundDiv('Finals', ['final']);
+            // Finale
+            const finals = createRoundDiv('Finale', ['final']);
             container.appendChild(finals);
         }
 

--- a/templates/overlay.html
+++ b/templates/overlay.html
@@ -623,7 +623,7 @@
             </div>
 
             <div class="path-indicator" id="pathIndicator">
-                Path to Victory: Round 1 → Quarterfinals → Semifinals → Finals
+                Path to Victory: Achtelfinale → Viertelfinale → Halbfinale → Finale
             </div>
         </div>
 
@@ -773,10 +773,10 @@
             
             // Create rounds
             const rounds = [
-                { name: 'Round 1', matches: ['r1_m1', 'r1_m2', 'r1_m3', 'r1_m4', 'r1_m5', 'r1_m6', 'r1_m7', 'r1_m8'] },
-                { name: 'Quarterfinals', matches: ['qf_m1', 'qf_m2', 'qf_m3', 'qf_m4'] },
-                { name: 'Semifinals', matches: ['sf_m1', 'sf_m2'] },
-                { name: 'Finals', matches: ['final'] }
+                { name: 'Achtelfinale', matches: ['r1_m1', 'r1_m2', 'r1_m3', 'r1_m4', 'r1_m5', 'r1_m6', 'r1_m7', 'r1_m8'] },
+                { name: 'Viertelfinale', matches: ['qf_m1', 'qf_m2', 'qf_m3', 'qf_m4'] },
+                { name: 'Halbfinale', matches: ['sf_m1', 'sf_m2'] },
+                { name: 'Finale', matches: ['final'] }
             ];
             
             rounds.forEach(round => {


### PR DESCRIPTION
## Summary
- Updates all tournament round names from English to German terminology
- Provides more appropriate German language labels for tournament structure
- Maintains all existing functionality while improving localization

## Changes Made
**Round Name Updates:**
- `"round1"` → `"Achtelfinale"` (Round of 16)
- `"quarterfinals"` → `"Viertelfinale"` (Quarterfinals)
- `"semifinals"` → `"Halbfinale"` (Semifinals) 
- `"finals"` → `"Finale"` (Finals)

**Files Modified:**
- **app.py**: Backend data structures and tournament bracket creation
- **control.html**: Control panel round display labels
- **overlay.html**: Tournament bracket overlay and path to victory display

## Test Plan
- [x] Generated test tournament data with German round names
- [x] Verified overlay match display shows "Achtelfinale" correctly
- [x] Confirmed tournament bracket displays all German round names
- [x] Tested path to victory shows German progression path
- [x] Verified control panel uses German round labels

All tournament functionality works identically with German round names.

🤖 Generated with [Claude Code](https://claude.ai/code)